### PR TITLE
Split test report into a separate workflow to workaround security restriction for forked repositories

### DIFF
--- a/.github/workflows/test-report.yml
+++ b/.github/workflows/test-report.yml
@@ -1,0 +1,18 @@
+name: 'test-report'
+on:
+  workflow_run:
+    workflows: ['build-test']
+    types:
+      - completed
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Test Report
+        uses: dorny/test-reporter@v1
+        if: success() || failure()
+        with:
+          artifact: test-results
+          name: JEST Tests
+          path: '*.xml'
+          reporter: jest-junit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,14 +49,13 @@ jobs:
           OCTOPUS_CLI_API_KEY: ${{ env.ADMIN_API_KEY }}
         run: npm run all
 
-      - name: Test Report
-        uses: dorny/test-reporter@v1
+      - name: Upload test report
+        uses: actions/upload-artifact@v3
         if: success() || failure()
         with:
-          name: JEST Tests
+          name: test-results
           path: reports/jest-*.xml
-          reporter: jest-junit
-      
+
       - name: Add server url to CORS
         run: |
           curl '${{ env.SERVER_URL }}/api/configuration/webportal/values' -X 'PUT' -H 'Content-Type: application/json' -H 'X-Octopus-ApiKey: ${{ env.ADMIN_API_KEY }}' --data-binary '{"Security":{"CorsWhitelist":"http://localhost,${{ env.SERVER_URL }}","ReferrerPolicy":"no-referrer","ContentSecurityPolicyEnabled":true,"HttpStrictTransportSecurityEnabled":false,"HttpStrictTransportSecurityMaxAge":31556926,"XOptions":{"XFrameOptionAllowFrom":null,"XFrameOptions":"None"}}}' -o /dev/null -s -w "%{http_code}\n"


### PR DESCRIPTION
As per the [recommended setup for public repositories](https://github.com/dorny/test-reporter#recommended-setup-for-public-repositories) section of the `dorny/test-reporter` README.

> Workflows triggered by pull requests from forked repositories are executed with read-only token and therefore can't create check runs. To workaround this security restriction, it's required to use two separate workflows:
> - `CI` runs in the context of the PR head branch with the read-only token. It executes the tests and uploads test results as a build artifact
> - `Test Report` runs in the context of the repository main branch with read/write token. It will download test results and create reports