### PR TITLE
feat: Add support for providing a base branch and return diff of commits

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ steps:
 | `server`         | The instance URL hosting Octopus Deploy (i.e. "https://octopus.example.com/"). The instance URL is required, but you may also use the OCTOPUS_URL environment variable.                                      |
 | `api_key`        | The API key used to access Octopus Deploy. An API key is required, but you may also use the OCTOPUS_API_KEY environment variable. It is strongly recommended that this value retrieved from a GitHub secret. |
 | `space`          | The name of a space within which this command will be executed. The space name is required, but you may also use the OCTOPUS_SPACE environment variable.                                                     |
+| `base_branch`    | The base branch to compare the commits to. If omitted only the last push commit will be used.                                   |
+| `github_token`   | GitHub_Token used for API call. Used when base_branch is provided.                                                                 |
 
 ## 🤝 Contributions
 

--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,10 @@ inputs:
     description: 'The base URL hosting Octopus Deploy (i.e. "https://octopus.example.com/"). It is recommended to retrieve this value from an environment variable.'
   space:
     description: 'The name or ID of a space within which this command will be executed. If omitted, the default space will be used.'
+  base_branch:
+    description: 'The base branch to compare the commits to. If omitted only the last push commit will be used.'
+  github_token:
+    description: 'GitHub_Token used for API call. Used when base_branch is provided.'
 
 runs:
   using: 'node20'

--- a/src/input-parameters.ts
+++ b/src/input-parameters.ts
@@ -21,6 +21,8 @@ export interface InputParameters {
   version: string
   branch?: string
   overwriteMode: OverwriteMode
+  baseBranch?: string
+  githubToken: string
 }
 
 export function get(isRetry: boolean): InputParameters {
@@ -36,7 +38,9 @@ export function get(isRetry: boolean): InputParameters {
     packages: getMultilineInput('packages', { required: true }),
     version: getInput('version', { required: true }),
     branch: getInput('branch') || undefined,
-    overwriteMode
+    overwriteMode,
+    baseBranch: getInput('base_branch') || undefined,
+    githubToken: getInput('github_token')
   }
 
   const errors: string[] = []


### PR DESCRIPTION
This enhancement introduces the capability to specify a base branch and utilize GitHub's [compare commits](https://docs.github.com/en/pull-requests/committing-changes-to-your-project/viewing-and-comparing-commits/comparing-commits) feature. This enables the generation of a commit list associated with the package.

It's important to note that this modification is non-breaking, activating only when both the `base_branch` and `github_token` inputs are provided.