### PR TITLE
Add check if transpiled javascript in dist has been updated

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,6 +69,23 @@ jobs:
           path: 'reports/jest-*.xml'
           reporter: jest-junit
 
+      - name: Compare the expected and actual dist/ directories
+        run: |
+          if [ "$(git diff --ignore-space-at-eol dist/ | wc -l)" -gt "0" ]; then
+            echo "Detected uncommitted changes after build.  See status below:"
+            git diff
+            exit 1
+          fi
+        id: diff
+
+      # If index.js was different than expected, upload the expected version as an artifact
+      - name: Upload dist as artifact if differences detected
+        uses: actions/upload-artifact@v3
+        if: ${{ failure() && steps.diff.conclusion == 'failure' }}
+        with:
+          name: dist
+          path: dist/
+
       - name: Add server url to CORS
         run: |
           curl '${{ env.SERVER_URL }}/api/configuration/webportal/values' -X 'PUT' -H 'Content-Type: application/json' -H 'X-Octopus-ApiKey: ${{ env.ADMIN_API_KEY }}' --data-binary '{"Security":{"CorsWhitelist":"http://localhost,${{ env.SERVER_URL }}","ReferrerPolicy":"no-referrer","ContentSecurityPolicyEnabled":true,"HttpStrictTransportSecurityEnabled":false,"HttpStrictTransportSecurityMaxAge":31556926,"XOptions":{"XFrameOptionAllowFrom":null,"XFrameOptions":"None"}}}' -o /dev/null -s -w "%{http_code}\n"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Compare the expected and actual dist/ directories
         run: |
           if [ "$(git diff --ignore-space-at-eol dist/ | wc -l)" -gt "0" ]; then
-            echo "Detected uncommitted changes after build.  See status below:"
+            echo "Detected uncommitted changes in transpiled javascript after build. Please run `npm run build` locally and commit the changes. See status below:"
             git diff
             exit 1
           fi

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,12 +31,6 @@ import process from 'process'
       }
     }
 
-    const i = 0
-
-    if (i > 0) {
-      throw new Error('test')
-    }
-
     const inputParameters = inputs.get(parseInt(process.env['GITHUB_RUN_ATTEMPT'] || '0') > 1)
 
     const config: ClientConfiguration = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,12 @@ import process from 'process'
       }
     }
 
+    const i = 0
+
+    if (i > 0) {
+      throw new Error('test')
+    }
+
     const inputParameters = inputs.get(parseInt(process.env['GITHUB_RUN_ATTEMPT'] || '0') > 1)
 
     const config: ClientConfiguration = {


### PR DESCRIPTION
This action is written in typescript and transpiled into javascript into `dist/index.js` which is used when the action runs. Ideally the contents of the js file should match the source code in any branch that might be used. We genreally expect and recommend that users will only use tagged releases of the action, however there isn't really anything stopping them from using the `main` branch (or any branch really) if they want to use some new feature or fix before it is released e.g.

```yaml
- uses: OctopusDeploy/push-build-information-action@main
  with: ...
```

Currently we don't enforce whether the transpiled javascript is up to date with the source code, and so there is a chance it could drift if someone contributing to the action doesn't know about this. 

The [dist workflow](https://github.com/OctopusDeploy/push-build-information-action/blob/main/.github/workflows/dist.yml) will perform the build and commit the changes as part of a PR to release a new version, however this doesn't feel ideal and doesn't add safety to the action during development.

This PR adds a check to the build make sure this happens, reminding authors to run `npm run build` locally and commit the changes as part of their PR.