### PR TITLE
Remove quotes from README.md example

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ steps:
     uses: OctopusDeploy/push-build-information-action@v3
     with:
       packages: |
-        '<packageId1>'
+        <packageId1>
       version: '<versionofpackages>'
 ```
 


### PR DESCRIPTION
The example in the readme has the packageId property as a multi-line string, but with single quotes around the value. This means that the id getting set includes the quotes, which means it doesn't match and therefore doesn't work.