### PR TITLE
Remove new line char from 'test' action distribution check message

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Compare the expected and actual dist/ directories
         run: |
           if [ "$(git diff --ignore-space-at-eol dist/ | wc -l)" -gt "0" ]; then
-            echo "Detected uncommitted changes in transpiled javascript after build. Please run `npm run build` locally and commit the changes. See status below:"
+            echo "Detected uncommitted changes in transpiled javascript after build. Please run 'npm run build' locally and commit the changes. See status below:"
             git diff
             exit 1
           fi


### PR DESCRIPTION
## Background 🌤️ 

Turns out that `n is a new line character! Who knew? Not me. 

## What's this? 🐌 

This just fixes up the 'test' action output so you can see the message to run 'npm run build' if the new distribution differs from the existing one. 

### Before
<img width="573" alt="image" src="https://github.com/user-attachments/assets/fc2a9fdf-5000-4fa3-8ea7-a88189c3ee9e">

### After
<img width="826" alt="image" src="https://github.com/user-attachments/assets/b0b8cfce-0279-46dd-99cb-b11498eecc1b">

## How to review 🔍 
✅ Can I make changes in this repo? 