### PR TITLE
Make newlines consistent across different OS

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
   },
   "scripts": {
     "all": "npm run format && npm run build && npm test",
-    "build": "tsc",
+    "build": "tsc --newLine lf",
     "format": "prettier --write **/*.ts",
     "format-check": "prettier --check **/*.ts",
     "prebuild": "eslint src/**/*.ts",


### PR DESCRIPTION
Recently we had a [security alert](https://github.com/OctopusDeploy/push-build-information-action/security/dependabot/16) which [dependabot created an automatic PR to fix for us](https://github.com/OctopusDeploy/push-build-information-action/pull/223). However this PR doesn't run `npm run build` which leads to a CI failure as the `dist/index.js` file isn't up to date. We tried running this locally and pushing the results but this still fails, even though it appears that the files are the same. 

It appears that the issue is to do with line encoding differences between the various OSs being used locally and in GitHub actions runners.

This PR forces `lf` newlines using `tsc --newLine lf` which seems to work.   