### PR TITLE
chore: Update to `actions/upload-artifact` v4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,7 +80,7 @@ jobs:
 
       # If index.js was different than expected, upload the expected version as an artifact
       - name: Upload dist as artifact if differences detected
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ failure() && steps.diff.conclusion == 'failure' }}
         with:
           name: dist


### PR DESCRIPTION
[V3 of artifact actions are being deprecated on Nov 30th 2024](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/) after which time workflows will fail. This PR updates to use v4.

[sc-97071]